### PR TITLE
feat: スペース文字のみでの登録を禁止するバリデーションの追加

### DIFF
--- a/lib/one_pound_steak/regex.rb
+++ b/lib/one_pound_steak/regex.rb
@@ -25,6 +25,8 @@ class Regex
   VALID_BYTE_OVER = /[^\p{In_Miscellaneous_Symbols_and_Pictographs}\p{In_Emoticons}]/
   # 英数混合のもので8文字以上
   VALID_MIXED_ALPHABETS = /\A(?=.*?[a-zA-Z])(?=.*?\d)[a-zA-Z\d]{8,100}+\z/
+  # 空白文字のみの入力を受け付けない
+  VALID_NOT_ONLY_SPACE = /[^\s　]+/
 
   VALID_PHONETIC = /\A[ァ-ヴ][ァ-ヴー・]*\z/
 end

--- a/lib/one_pound_steak/user.rb
+++ b/lib/one_pound_steak/user.rb
@@ -18,11 +18,15 @@ module OnePoundSteak
     end
 
     def family_name(param)
-      StringParam.new.size_over(param, MAX_NAME_SIZE, 'family_name')
+      is_valid, message = StringParam.new.size_over(param, MAX_NAME_SIZE, 'family_name')
+      return [is_valid, message] unless is_valid
+      Common.regex_check('family_name', param, Regex::VALID_NOT_ONLY_SPACE)
     end
 
     def given_name(param)
-      StringParam.new.size_over(param, MAX_NAME_SIZE, 'given_name')
+      is_valid, message = StringParam.new.size_over(param, MAX_NAME_SIZE, 'given_name')
+      return [is_valid, message] unless is_valid
+      Common.regex_check('given_name', param, Regex::VALID_NOT_ONLY_SPACE)
     end
 
     def first_ruby(param)

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -57,6 +57,27 @@ RSpec.describe 'OnePoundSteak' do
         expect(valid).to eq(false)
         expect(message).to eq('family_nameが取得できませんでした')
       end
+      
+      it "prohibits registration with only space characters" do
+        valid, message = @validate.family_name('') # 空文字列
+        expect(valid).to eq(false)
+        expect(message).to eq('family_nameの形式が不正です')
+        valid, message = @validate.family_name(' ') # スペース１つ
+        expect(valid).to eq(false)
+        expect(message).to eq('family_nameの形式が不正です')
+        valid, message = @validate.family_name('   ') # スペース３つ
+        expect(valid).to eq(false)
+        expect(message).to eq('family_nameの形式が不正です')
+        valid, message = @validate.family_name('　') # 全角スペース
+        expect(valid).to eq(false)
+        expect(message).to eq('family_nameの形式が不正です')
+        valid, message = @validate.family_name("\n") # 改行
+        expect(valid).to eq(false)
+        expect(message).to eq('family_nameの形式が不正です')
+        valid, message = @validate.family_name('  a   ')
+        expect(valid).to eq(true)
+        expect(message).to eq('ok family_name')
+      end
     end
 
     context "given_name" do
@@ -69,6 +90,27 @@ RSpec.describe 'OnePoundSteak' do
         valid, message = @validate.given_name(nil)
         expect(valid).to eq(false)
         expect(message).to eq('given_nameが取得できませんでした')
+      end
+
+      it "prohibits registration with only space characters" do
+        valid, message = @validate.given_name('') # 空文字列
+        expect(valid).to eq(false)
+        expect(message).to eq('given_nameの形式が不正です')
+        valid, message = @validate.given_name(' ') # スペース１つ
+        expect(valid).to eq(false)
+        expect(message).to eq('given_nameの形式が不正です')
+        valid, message = @validate.given_name('   ') # スペース３つ
+        expect(valid).to eq(false)
+        expect(message).to eq('given_nameの形式が不正です')
+        valid, message = @validate.given_name('　') # 全角スペース
+        expect(valid).to eq(false)
+        expect(message).to eq('given_nameの形式が不正です')
+        valid, message = @validate.given_name("\n") # 改行
+        expect(valid).to eq(false)
+        expect(message).to eq('given_nameの形式が不正です')
+        valid, message = @validate.given_name('  a   ')
+        expect(valid).to eq(true)
+        expect(message).to eq('ok given_name')
       end
     end
 


### PR DESCRIPTION
# 概要

- User の family_name 及び given_name で 空白文字のみからなる文字列を不正とみなすように変更

## やりたいこと

[WIP]などであれば、あと何を追加するのかをリストにするとわかりやすい

## やったこと

- スペースのみからなる文字列ではない１文字以上の文字列を正規表現で表した
- （`/[^\s　]+/`：`\s`の直後の文字は全角スペース）
- `User.given_name`, `User.family_name` に上記の正規表現を用いたバリデーションを追加
- 対応するテストの追加

## やらないこと

やったほうが良さそうだけど、諸事情(プルリクがでかくなるなど)でやらないと判断したものを記述する

# 観点

- 実装に不適切なところはないか
- テストが通ること
- テストケースが十分か

# 参考
